### PR TITLE
Fix blog fetch paths for GitHub Pages

### DIFF
--- a/front/src/utils/blogUtils.js
+++ b/front/src/utils/blogUtils.js
@@ -2,6 +2,9 @@
 import matter from 'gray-matter';
 import { format, parseISO } from 'date-fns';
 
+// Base path for assets when deployed to GitHub Pages
+const base = process.env.PUBLIC_URL || '';
+
 // Blog configuration
 export const BLOG_CONFIG = {
   categories: {
@@ -57,7 +60,7 @@ export async function getPostsManifest() {
   console.log('🔍 Loading posts manifest...');
   
   try {
-    const response = await fetch('/blog/posts-manifest.json');
+    const response = await fetch(`${base}/blog/posts-manifest.json`);
     console.log(`📡 Manifest response status: ${response.status}`);
     
     if (!response.ok) {
@@ -98,7 +101,7 @@ export async function loadAllPosts() {
     const posts = [];
 
     for (const postInfo of manifest) {
-      const fullPath = `/blog/posts/${postInfo.category}/${postInfo.filename}`;
+      const fullPath = `${base}/blog/posts/${postInfo.category}/${postInfo.filename}`;
       console.log(`📖 Processing post: ${postInfo.filename} from ${postInfo.category}`);
       
       const postData = await loadMarkdownFile(fullPath);
@@ -144,7 +147,7 @@ export async function loadAllPosts() {
 // ... rest of the functions remain the same
 export async function getPostBySlug(category, slug) {
   try {
-    const postData = await loadMarkdownFile(`/blog/posts/${category}/${slug}.md`);
+    const postData = await loadMarkdownFile(`${base}/blog/posts/${category}/${slug}.md`);
     
     if (!postData) {
       return null;


### PR DESCRIPTION
## Summary
- add `base` constant from `PUBLIC_URL`
- prefix blog fetch paths with the base URL so posts load in deployed builds

## Testing
- `npm test -- --watchAll=false` *(fails: react-scripts not found)*

------
https://chatgpt.com/codex/tasks/task_e_684276032820832bb00ce16f788e9f9f