### PR TITLE
Fix runtime base path for blog utils

### DIFF
--- a/front/src/utils/blogUtils.js
+++ b/front/src/utils/blogUtils.js
@@ -3,7 +3,11 @@ import matter from 'gray-matter';
 import { format, parseISO } from 'date-fns';
 
 // Base path for assets when deployed to GitHub Pages
-const base = process.env.PUBLIC_URL || '';
+const base =
+  process.env.PUBLIC_URL ||
+  (typeof window !== 'undefined'
+    ? window.location.pathname.replace(/\/[^\/]*$/, '')
+    : '');
 
 // Blog configuration
 export const BLOG_CONFIG = {


### PR DESCRIPTION
## Summary
- tweak blog utilities to compute base path at runtime when `PUBLIC_URL` isn't set

## Testing
- `npm run build` *(fails: react-scripts not found)*

------
https://chatgpt.com/codex/tasks/task_e_6842797d88e8832b81744b08d8351d5f