### PR TITLE
fix: Improve mobile blog view with reduced margins and better readabi…

### DIFF
--- a/front/src/index.css
+++ b/front/src/index.css
@@ -185,11 +185,21 @@ html,body{overscroll-behavior:none;position:relative;height:100%;min-height:100v
   }
 
   /* Card sizing for improved readability on phones */
-  .mobile-card-container{padding-left:1rem!important;padding-right:1rem!important}
+  .mobile-card-container{padding-left:0.5rem!important;padding-right:0.5rem!important}
   /* Slightly tighter cards on phones to allow more content on screen */
   .mobile-card{margin-left:0!important;margin-right:0!important;padding:1rem!important;border-radius:.875rem!important;margin-bottom:1rem!important}
   .mobile-card-large{padding:1.25rem!important;font-size:1rem!important;line-height:1.5!important}
   .mobile-card-optimized{width:100%!important;box-sizing:border-box!important}
+
+  /* Blog content specific optimizations */
+  article .bg-white, article .dark\:bg-gray-800{padding:1rem!important}
+
+  /* Better text readability on blog posts */
+  article p, article li{font-size:1rem!important;line-height:1.65!important}
+  article h1, article h2, article h3{margin-top:1.5rem!important;margin-bottom:0.75rem!important}
+
+  /* Excerpt boxes on mobile - reduce padding */
+  article .mb-8.p-6{padding:1rem!important;margin-bottom:1.5rem!important}
 
   /* Text inside cards */
   /* Slightly smaller typography to fit more content while keeping proportions */
@@ -228,8 +238,11 @@ html,body{overscroll-behavior:none;position:relative;height:100%;min-height:100v
 @media (max-width:480px){
   header[class*="fixed"]{min-height:76px}
   .hero-section{padding-top:5rem!important;min-height:calc(100dvh - 3.5rem)!important;height:auto!important}
-  .mobile-card-container{padding-left:.75rem!important;padding-right:.75rem!important}
+  .mobile-card-container{padding-left:0.35rem!important;padding-right:0.35rem!important}
   .mobile-card{padding:1.125rem!important}
+
+  /* Even tighter blog content on small phones */
+  article .bg-white, article .dark\:bg-gray-800{padding:0.875rem!important}
   
   /* Ensure hero container has enough space on small phones */
   .h-\[calc\(100dvh-5\.5rem\)\] {

--- a/front/src/pages/BlogCategoryPage.jsx
+++ b/front/src/pages/BlogCategoryPage.jsx
@@ -256,8 +256,8 @@ export default function BlogCategoryPage() {
         <div className="absolute top-40 right-20 w-72 h-72 rounded-full bg-blue-100/50 dark:bg-blue-900/20 blur-3xl -z-10"></div>
         <div className="absolute -bottom-20 -left-20 w-80 h-80 rounded-full bg-indigo-100/30 dark:bg-indigo-900/10 blur-3xl -z-10"></div>
         
-        <div className="container mx-auto px-6">
-          <motion.div 
+        <div className="container mx-auto px-3 md:px-6">
+          <motion.div
             initial="hidden"
             animate="visible"
             variants={staggerContainer}
@@ -313,9 +313,9 @@ export default function BlogCategoryPage() {
       </motion.section>
       
       {/* Posts Grid */}
-      <section className="py-16">
-        <div className="container mx-auto px-6">
-          <motion.div 
+      <section className="py-8 md:py-16">
+        <div className="container mx-auto px-3 md:px-6">
+          <motion.div
             initial={false}
             whileInView="visible"
             viewport={{ once: true, margin: "-100px" }}

--- a/front/src/pages/BlogHomePage.jsx
+++ b/front/src/pages/BlogHomePage.jsx
@@ -273,8 +273,8 @@ export default function BlogHomePage() {
         <div className="absolute top-40 right-20 w-72 h-72 rounded-full bg-blue-100/50 dark:bg-blue-900/20 blur-3xl -z-10"></div>
         <div className="absolute -bottom-20 -left-20 w-80 h-80 rounded-full bg-indigo-100/30 dark:bg-indigo-900/10 blur-3xl -z-10"></div>
         
-  <div className="container mx-auto px-6 -mt-10 mobile-card-container">
-          <motion.div 
+  <div className="container mx-auto px-3 md:px-6 -mt-10 mobile-card-container">
+          <motion.div
             initial="hidden"
             animate="visible"
             variants={staggerContainer}
@@ -373,8 +373,8 @@ export default function BlogHomePage() {
       
       {/* Posts Grid */}
       <section className="py-0 pb-16">
-        <div className="container mx-auto px-6 mobile-card-container">
-          <motion.div 
+        <div className="container mx-auto px-3 md:px-6 mobile-card-container">
+          <motion.div
             initial={false}
             whileInView="visible"
             viewport={{ once: true, margin: "0px" }}
@@ -546,8 +546,8 @@ export default function BlogHomePage() {
       
       {/* CTA Section */}
       <section className="py-16 bg-gray-900 dark:bg-gray-950">
-        <div className="container mx-auto px-6 mobile-card-container">
-          <motion.div 
+        <div className="container mx-auto px-3 md:px-6 mobile-card-container">
+          <motion.div
             initial="hidden"
             whileInView="visible"
             viewport={{ once: true, margin: "0px" }}

--- a/front/src/pages/BlogPostPage.jsx
+++ b/front/src/pages/BlogPostPage.jsx
@@ -316,8 +316,8 @@ export default function BlogPostPage() {
         
         {/* Content Overlay */}
         <div className="relative z-10 h-full flex items-end">
-          <div className="container mx-auto px-6 pb-16">
-            <motion.div 
+          <div className="container mx-auto px-3 md:px-6 pb-12 md:pb-16">
+            <motion.div
               initial="hidden"
               animate="visible"
               variants={fadeInUp}
@@ -393,18 +393,18 @@ export default function BlogPostPage() {
       </motion.section>
       
       {/* Post Content */}
-      <section className="py-16">
-        <div className="container mx-auto px-6">
+      <section className="py-8 md:py-16">
+        <div className="container mx-auto px-3 md:px-6">
           <div className="max-w-7xl mx-auto">
             <div className="flex flex-col lg:flex-row gap-12">
               {/* Main Content */}
-              <motion.article 
+              <motion.article
                 initial="hidden"
                 animate="visible"
                 variants={slideInLeft}
                 className="lg:w-3/4"
               >
-                <div className="bg-white dark:bg-gray-800 rounded-xl shadow-lg p-8 md:p-12 border border-gray-100 dark:border-gray-700">
+                <div className="bg-white dark:bg-gray-800 rounded-xl shadow-lg p-4 md:p-8 lg:p-12 border border-gray-100 dark:border-gray-700">
                   {post.excerpt && (
                     <div className="mb-8 p-6 bg-blue-50 dark:bg-blue-900/20 rounded-lg border-l-4 border-blue-500">
                       <p className="text-lg text-gray-700 dark:text-gray-300 italic leading-relaxed">


### PR DESCRIPTION
Reduced excessive padding and margins on mobile devices:
- BlogPostPage: Changed px-6 to px-3 on mobile, reduced article padding from p-8 to p-4
- BlogHomePage: Reduced container padding to px-3 on mobile
- BlogCategoryPage: Applied same padding adjustments
- CSS: Reduced mobile-card-container padding from 1rem to 0.5rem
- Added specific blog content optimizations for better text readability
- Improved excerpt box padding on mobile devices

These changes maximize readable content area while maintaining good UX.